### PR TITLE
execute one process, to safety shutdown

### DIFF
--- a/packages/discord/discordAPI.py
+++ b/packages/discord/discordAPI.py
@@ -1,9 +1,11 @@
 from app_setting import supabase_client
 import discord
 import os
+import uvicorn
 import logging
 import requests
 from fastapi import FastAPI
+from threading import Thread
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -14,11 +16,20 @@ api = FastAPI()
 def health():
     return {"health": "ok"}
 
+def run():
+    uvicorn.run(api, host='0.0.0.0', port=8000)
+
+def keep_alive():
+    t = Thread(target=run)
+    t.daemon = True
+    t.start()
+
 client = discord.Client(intents=discord.Intents.all())
 
 headers = {
     'Authorization': f'Bot {os.getenv("DISCORD_BOT_TOKEN")}',
 }
+
 
 def get_priority_and_sentient(message_text):
     response = requests.get(
@@ -59,4 +70,5 @@ async def on_message(message):
     supabase_client.table("messages").insert(messages).execute()
 
 if __name__ == "__main__":
+    keep_alive()
     client.run(os.getenv("DISCORD_BOT_TOKEN"))

--- a/packages/discord/dockerfile
+++ b/packages/discord/dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn discordAPI:api --reload --host 0.0.0.0 --port 8000 & python discordAPI.py"]
+CMD ["python", "discordAPI.py"]

--- a/packages/slack/dockerfile
+++ b/packages/slack/dockerfile
@@ -17,10 +17,4 @@ COPY . .
 
 EXPOSE 8000
 
-# ADD entrypoint.sh /
-# RUN chmod +x /entrypoint.sh
-
-# CMD ["python", "slack_bot.py"]
-# CMD ["python", "slack_bot.py", "&", ";" "uvicorn", "slack_bot:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
-CMD ["sh", "-c", "uvicorn slack_bot:api --reload --host 0.0.0.0 --port 8000 & python slack_bot.py"]
-# ENTRYPOINT /entrypoint.sh
+CMD ["python", "slack_bot.py"]

--- a/packages/slack/slack_bot.py
+++ b/packages/slack/slack_bot.py
@@ -3,6 +3,8 @@ import os
 import uuid
 
 from fastapi import FastAPI
+from threading import Thread
+import uvicorn
 import requests
 from app_setting import supabase_client
 from dotenv import load_dotenv
@@ -24,7 +26,13 @@ api = FastAPI()
 def health():
     return {"health": "ok"}
 
-# 感情分析と優先度
+def run():
+    uvicorn.run(api, host='0.0.0.0', port=8000)
+
+def keep_alive():
+    t = Thread(target=run)
+    t.daemon = True
+    t.start()
 
 
 def get_priority_and_sentient(message_text):
@@ -99,4 +107,5 @@ def handle_message(event):
 
 # アプリを起動
 if __name__ == "__main__":
+    keep_alive()
     SocketModeHandler(app=app, app_token=os.environ["SLACK_APP_TOKEN"]).start()


### PR DESCRIPTION
pythonのthreadingというのを使って1プロセスでbotとfastapiを立ち上げる。
バックグラウンドプロセス落ちずに`docker (stop | kill)`が必要だったけど`ctrl-c`でコンテナが終了するようになった。
refs: https://qiita.com/Erytheia/items/2f64c06d6d8a4f802390#%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4