### PR TITLE
fix(slack): supabaseへのアクセストークンリクエストを削減

### DIFF
--- a/packages/api/src/app.py
+++ b/packages/api/src/app.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import Depends
 from src.app_setting import app, get_current_user
-from src.const.message import Message, MessageResponse
+from src.const.message import Message, MessageResponse, App
 from src.predict.emotion.emotion import analyze_emotion
 from src.predict.priority.priority import prioritize_message
 from src.sync_app.discord.discord import get_discord_message
@@ -49,7 +49,7 @@ async def get_messages(
 
     responses = []
     for message in messages:
-        if message.app.SLACK:
+        if message.app == App.SLACK:
             try:
                 responses.append(
                     get_slack_message(
@@ -63,7 +63,7 @@ async def get_messages(
                 logger.error('slack server error')
                 logger.error(e)
 
-        if message.app.DISCORD:
+        if message.app == App.DISCORD:
             try:
                 responses.append(
                     get_discord_message(

--- a/packages/api/src/sync_app/slack/slack.py
+++ b/packages/api/src/sync_app/slack/slack.py
@@ -1,23 +1,12 @@
 from datetime import datetime
 
-from src.decode import decrypt
 from slack_sdk import WebClient
 from src.const.message import MessageResponse
-from src.app_setting import supabase_client
 
 
 def get_slack_message(
-    user_id: str, server_id: str, channel_id: str, message_id: str
+    slack_access_token: str, server_id: str, channel_id: str, message_id: str
 ) -> MessageResponse:
-    # 暗号化されたトークンを取得
-    encrypted_token = (
-        supabase_client.table("slack_settings")
-        .select("access_token")
-        .eq("user_id", user_id)
-        .execute()
-    ).data[0]["access_token"]
-    # 複合化
-    slack_access_token = decrypt(encrypted_token)
 
     client = WebClient(token=slack_access_token)
 


### PR DESCRIPTION
- Slack側がmessage_id毎にsupabaseに、アクセストークンのリクエストを送っていたので、それを一回で済むように変更しました。

- message.appの書き方がおかしくて、slackのメッセージなのにdiscordにもリクエストが送られるようになっていたので、それも修正しました。