### PR TITLE
feat(api): Pythonのformatter, linterであるRuffを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,8 +124,6 @@ dmypy.json
 # Pytest Cache
 .pytest_cache/
 
-# VSCode
-.vscode/
 
 # Local environment settings
 *.env

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["biomejs.biome"]
+  "recommendations": ["biomejs.biome", "charliermarsh.ruff"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,16 @@
   },
   "editor.quickSuggestions": {
     "strings": "on"
+  },
+
+  "ruff.lint.args": [
+    "--ignore=E201,E202,E225,E226,E501",
+  ],
+  "[python]": {
+      "editor.defaultFormatter": "charliermarsh.ruff",
+      "editor.formatOnSave": true,
+      "editor.codeActionsOnSave": {
+          "source.organizeImports": "explicit",
+      }
   }
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,40 @@
+# 一行80文字まで
+line-length = 80
+# インデントは4スペース
+indent-width = 4
+
+
+# python 3.11
+target-version = "py311"
+
+
+[lint]
+select = [
+    "E",    # pycodestyle error
+    "F",    # Pyflakes
+    "W",    # pycodestyle warning
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "N"     # pep8-naming
+]
+
+# 除外するエラー
+ignore = ["E201", "E202", "E225", "E226"]
+# ruff --fix で自動修正できるエラー
+fixable = ["E4", "E7", "E9", "F", "I"]
+
+[lint.isort]
+combine-as-imports = true
+detect-same-package = false
+force-sort-within-sections = true
+
+
+[format]
+# ダブルクォーテーションで統一.
+quote-style = "double"
+
+# インデントはスペースのみ.
+indent-style = "space"
+
+# 末行の改行を入れる.
+line-ending = "auto"


### PR DESCRIPTION
Pythonのフォーマッターとリンターの設定を作りました。

Ruffと呼ばれる、isort, black, flake8を合体させたようなツールを使っています。

VS Code上なら、明示的にセーブするとフォーマットが働くようになっています。