### PR TITLE
labeler.ymlのブランチ名指定を汎用的に変更

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,10 +21,10 @@
 
 # Branch pattern
 🚀 Feature:
-  - head-branch: ['^feature/', '^feat/']
+  - head-branch: ['*feature*', '*feat*']
 🛠️ Fix:
-  - head-branch: ['^fix/']
+  - head-branch: ['*fix*']
 🚨 Hot Fix:
-  - head-branch: ['^hotfix/']
+  - head-branch: ['*hotfix*']
 🔄 Refactor:
-  - head-branch: ['^refactor/']
+  - head-branch: ['*refactor*']


### PR DESCRIPTION
`^feat/`を`*feat*`にして、ケバブケースでも`/`を使うケースでも、どちらでも対応させる