### PR TITLE
fix(web): Slackの連携成功画面の文字を黒色に変更しました

### DIFF
--- a/packages/web/src/app/(authenticated)/settings/success/appType.ts
+++ b/packages/web/src/app/(authenticated)/settings/success/appType.ts
@@ -15,7 +15,7 @@ const AppType = [
     name: 'Slack',
     img: SlackImg,
     backgroundColorClass: 'bg-white',
-    textColor: 'primary',
+    textColor: 'black',
   },
   {
     type: 'github',


### PR DESCRIPTION
fix(web): Slackの連携成功画面の文字を黒色に変更しました