### PR TITLE
fix(web): Tailwind CSS v3.3 から require('@tailwindcss/line-clamp')はもうデフォルトで入っているようなので削除しました

### DIFF
--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -76,6 +76,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate'), require('@tailwindcss/line-clamp')],
+  plugins: [require('tailwindcss-animate')],
 };
 export default config;


### PR DESCRIPTION
fix(web): Tailwind CSS v3.3 から require('@tailwindcss/line-clamp')はもうデフォルトで入っているようなので削除しました