### PR TITLE
chore: add apprunner deploy

### DIFF
--- a/.github/ci/go.mod
+++ b/.github/ci/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.31.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.36
+	github.com/aws/aws-sdk-go-v2/service/apprunner v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.54.0
 )
 

--- a/.github/ci/go.sum
+++ b/.github/ci/go.sum
@@ -12,6 +12,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.18 h1:Z7IdFUONvTcvS7Yuht
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.18/go.mod h1:DkKMmksZVVyat+Y+r1dEOgJEfUeA7UngIHWeKsi0yNc=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.31.0 h1:G8QMM1uGihmus8Xsg4LDXbQ7xpJisPrSXW5OIrP7q2M=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.31.0/go.mod h1:6VHD8l7WdVP6s6haYvfXpO632tCCvKI9etO9sbwSBOs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.5 h1:QFASJGfT8wMXtuP3D5CRmMjARHv9ZmzFUMJznHDOY3w=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.5/go.mod h1:QdZ3OmoIjSX+8D1OPAzPxDfjXASbBMDsz9qvtyIhtik=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.20 h1:Xbwbmk44URTiHNx6PNo0ujDE6ERlsCKJD3u1zfnzAPg=

--- a/.github/ci/slack_token_rotation.go
+++ b/.github/ci/slack_token_rotation.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/apprunner"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
@@ -23,12 +24,11 @@ type slackTokenResponse struct {
 }
 
 // get refresh token
-func getRefreshToken(ctx context.Context, cfg aws.Config) (token string, err error) {
+func getRefreshToken(ctx context.Context, client *ssm.Client) (token string, err error) {
 	input := &ssm.GetParameterInput{
 		Name:           aws.String("slack_refresh_token"),
 		WithDecryption: aws.Bool(true),
 	}
-	client := ssm.NewFromConfig(cfg)
 
 	parameter, err := client.GetParameter(ctx, input)
 	if err != nil {
@@ -75,7 +75,7 @@ func refreshToken(refreshToken string) (slackResponse slackTokenResponse, err er
 }
 
 // set new access token to ssm parameter store
-func setToken(ctx context.Context, cfg aws.Config, token, refreshToken string) error {
+func setToken(ctx context.Context, client *ssm.Client, token, refreshToken string) error {
 	botInput := &ssm.PutParameterInput{
 		Name:      aws.String("slack_bot_token"),
 		Value:     &token,
@@ -87,8 +87,6 @@ func setToken(ctx context.Context, cfg aws.Config, token, refreshToken string) e
 		Value:     &refreshToken,
 		Overwrite: aws.Bool(true),
 	}
-
-	client := ssm.NewFromConfig(cfg)
 
 	// bot
 	_, err := client.PutParameter(ctx, botInput)
@@ -105,6 +103,19 @@ func setToken(ctx context.Context, cfg aws.Config, token, refreshToken string) e
 	return nil
 }
 
+// deploy app runner to use refreshed token
+func startDeploy(ctx context.Context, client *apprunner.Client) error {
+	arn := "arn:aws:apprunner:ap-northeast-1:451153100141:service/all_in_slack/a1d29e5b95024ae9bd54357249909875"
+	input := &apprunner.StartDeploymentInput{ServiceArn: aws.String(arn)}
+
+	_, err := client.StartDeployment(ctx, input)
+	if err != nil {
+		return fmt.Errorf("deployment: %s", err)
+	}
+
+	return nil
+}
+
 func main() {
 	ctx := context.TODO()
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("ap-northeast-1"))
@@ -112,26 +123,32 @@ func main() {
 		fmt.Printf("failed to load SDK config. %s\n", err)
 		os.Exit(1)
 	}
+	ssmClient := ssm.NewFromConfig(cfg)
 
-	token, err := getRefreshToken(ctx, cfg)
-	if err != nil {
-		fmt.Printf("failed to get refresh token: %s\n", err)
-	}
+	token, err := getRefreshToken(ctx, ssmClient)
+	printErrorAndExit(err)
 
 	refresh, err := refreshToken(token)
-	if err != nil {
-		fmt.Printf("failed to %s\n", err)
-		os.Exit(1)
-	}
+	printErrorAndExit(err)
 	if refresh.Error != "" {
 		fmt.Printf("failed to refresh token.\n%s", refresh.Error)
 		os.Exit(1)
 	}
 
-	err = setToken(ctx, cfg, refresh.AccessToken, refresh.RefreshToken)
+	err = setToken(ctx, ssmClient, refresh.AccessToken, refresh.RefreshToken)
+	printErrorAndExit(err)
+
+	// app runner deploy
+	apprunnerClient := apprunner.NewFromConfig(cfg)
+	err = startDeploy(ctx, apprunnerClient)
+	printErrorAndExit(err)
+
+	os.Exit(0)
+}
+
+func printErrorAndExit(err error) {
 	if err != nil {
-		fmt.Printf("failed to set token\n%s", err)
+		fmt.Printf("failed to %s\n", err)
 		os.Exit(1)
 	}
-	os.Exit(0)
 }


### PR DESCRIPTION
slackのトークンをリフレッシュした後にapp runnerをデプロイし直さないとリフレッシュ後のトークンを参照しないから。